### PR TITLE
Added FAA Pending Requests Feature V1

### DIFF
--- a/rti-master/src/main/java/nic/rti/master/controller/FAAPendingRequestController.java
+++ b/rti-master/src/main/java/nic/rti/master/controller/FAAPendingRequestController.java
@@ -1,0 +1,38 @@
+package nic.rti.master.controller;
+
+import lombok.RequiredArgsConstructor;
+import nic.rti.master.dto.FinalResponseDTO;
+import nic.rti.master.dto.PendingRequestDTO;
+import nic.rti.master.service.FAAPendingRequestService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.InvalidParameterException;
+
+
+@RestController
+@RequestMapping("/rti-faa")
+@RequiredArgsConstructor
+public class FAAPendingRequestController {
+
+    private final FAAPendingRequestService pendingRequestService;
+
+    @GetMapping("/pending-requests")
+    public FinalResponseDTO getPendingRequests(
+            @RequestParam String records_type,
+            @RequestParam Integer appl_id,
+            @RequestParam(required = false, defaultValue = "50") Integer limit,
+            @RequestParam(required = false, defaultValue = "0") Integer offset
+    ) {
+        PendingRequestDTO dto = new PendingRequestDTO();
+        dto.setRecordsType(records_type);
+        dto.setApplId(appl_id);
+        dto.setLimit(limit);
+        dto.setOffset(offset);
+
+        return pendingRequestService.fetchPendingRequests(dto);
+    }
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/FAAPendingRequestRepository.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/FAAPendingRequestRepository.java
@@ -1,0 +1,24 @@
+package nic.rti.master.dao;
+
+import nic.rti.master.dto.PendingRequestResponseDTO;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FAAPendingRequestRepository {
+    List<PendingRequestResponseDTO> fetchUnderProcess(Integer applId, Integer limit, Integer offset);
+    long countUnderProcess(Integer applId);
+
+//    List<PendingRequestResponseDTO> fetchCommentCPIO(Integer applId, Integer limit, Integer offset);
+//    long countCommentCPIO(Integer applId);
+//
+//    List<PendingRequestResponseDTO> fetchModify(Integer applId, Integer limit, Integer offset);
+//    long countModify(Integer applId);
+//
+//    List<PendingRequestResponseDTO> fetchNew(Integer applId, Integer limit, Integer offset);
+//    long countNew(Integer applId);
+//
+//    List<PendingRequestResponseDTO> fetchPending20Days(Integer applId, Integer limit, Integer offset);
+//    long countPending20Days(Integer applId);
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/impl/FAAPendingRequestRepositoryImpl.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/impl/FAAPendingRequestRepositoryImpl.java
@@ -1,0 +1,94 @@
+package nic.rti.master.dao.impl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.Data;
+import nic.rti.master.dao.FAAPendingRequestRepository;
+import nic.rti.master.dto.PendingRequestDTO;
+import nic.rti.master.dto.PendingRequestResponseDTO;
+import org.springframework.stereotype.Repository;
+import jakarta.persistence.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+
+
+@Repository
+public class FAAPendingRequestRepositoryImpl implements FAAPendingRequestRepository {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public List<PendingRequestResponseDTO>  fetchUnderProcess(Integer applId, Integer limit, Integer offset){
+        String sql= """
+                SELECT a.registration_no,
+                a.name,
+                TO_CHAR(a.recvd_date,'DD/MM/YYYY') AS recv_date,
+                TO_CHAR(a.entry_date,'YY-MM-DD"T"HH24:MI:SS"Z"')AS entry_date
+                
+                FROM RTIMIS.appeal a
+                JOIN (
+                    SELECT  registration_no, MAX(action_srno) AS max_srno
+                    FROM RTIMIS.action_history
+                    GROUP BY registration_no
+                   ) max_actions ON a.registration_no=max_actions.registration_no
+                   JOIN RTIMIS.action_history ah ON ah.registration_no=max_actions.registration_no
+                   AND ah.action_srno=max_actions.max_srno
+                   
+                   WHERE ah.action_status IN ('70','7A','7D','7C')
+                   AND a.closing_date IS NULL
+                   AND a.applid = :applId
+                   ORDER BY a.entry_date DESC
+                   LIMIT :limit OFFSET :offset
+                """  ;
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("applId",applId);
+        query.setParameter("limit",limit);
+        query.setParameter("offset",offset);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows=query.getResultList();
+        List<PendingRequestResponseDTO> dtoList=new ArrayList<>();
+
+        for (Object[] row:rows){
+            PendingRequestResponseDTO dto = new PendingRequestResponseDTO();
+
+            dto.setRegistrationNo((String)row[0]);
+            dto.setName((String)row[1]);
+            dto.setRecvDate((String) row[2]);
+            dto.setEntryDate((String) row[3]);
+            dtoList.add(dto);
+
+        }
+        return dtoList;
+
+    }
+
+    //impliment this temporarily for testing purpose
+
+    public long countUnderProcess(Integer applId) {
+        String sql = """
+        SELECT COUNT(*) 
+        FROM RTIMIS.appeal a
+        JOIN (
+            SELECT registration_no, MAX(action_srno) AS max_srno
+            FROM RTIMIS.action_history
+            GROUP BY registration_no
+        ) max_actions ON a.registration_no = max_actions.registration_no
+        JOIN RTIMIS.action_history ah ON ah.registration_no = max_actions.registration_no
+            AND ah.action_srno = max_actions.max_srno
+        WHERE ah.action_status IN ('70','7A','7D','7C')
+            AND a.closing_date IS NULL
+            AND a.applid = :applId
+    """;
+
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("applId", applId);
+        Object result = query.getSingleResult();
+        return ((Number) result).longValue();
+    }
+
+
+}

--- a/rti-master/src/main/java/nic/rti/master/dto/FinalResponseDTO.java
+++ b/rti-master/src/main/java/nic/rti/master/dto/FinalResponseDTO.java
@@ -1,0 +1,18 @@
+package nic.rti.master.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class FinalResponseDTO {
+    private String status;
+    private List<PendingRequestResponseDTO> data;
+    private PaginationDTO pagination;
+    // constructor
+    public FinalResponseDTO(String status, List<PendingRequestResponseDTO> data, PaginationDTO pagination) {
+        this.status = status;
+        this.data = data;
+        this.pagination = pagination;
+    }
+
+}

--- a/rti-master/src/main/java/nic/rti/master/dto/PaginationDTO.java
+++ b/rti-master/src/main/java/nic/rti/master/dto/PaginationDTO.java
@@ -1,0 +1,19 @@
+package nic.rti.master.dto;
+import lombok.Data;
+
+@Data
+public class PaginationDTO {
+    private Integer limit;
+    private Integer offset;
+    private Long totalCount;
+    private Boolean hasMore;
+
+    //constructor
+    public PaginationDTO(Integer limit, Integer offset, Long totalCount, Boolean hasMore) {
+        this.limit = limit;
+        this.offset = offset;
+        this.totalCount = totalCount;
+        this.hasMore = hasMore;
+    }
+
+}

--- a/rti-master/src/main/java/nic/rti/master/dto/PendingRequestDTO.java
+++ b/rti-master/src/main/java/nic/rti/master/dto/PendingRequestDTO.java
@@ -1,0 +1,11 @@
+package nic.rti.master.dto;
+
+import lombok.Data;
+
+@Data
+public class PendingRequestDTO {
+    private String recordsType;
+    private Integer applId;
+    private Integer limit=50;
+    private Integer offset=0;
+}

--- a/rti-master/src/main/java/nic/rti/master/dto/PendingRequestResponseDTO.java
+++ b/rti-master/src/main/java/nic/rti/master/dto/PendingRequestResponseDTO.java
@@ -1,0 +1,16 @@
+package nic.rti.master.dto;
+
+import lombok.Data;
+
+@Data
+public class PendingRequestResponseDTO {
+    private String registrationNo;
+    private String name;
+    private String recvDate;
+    private String entryDate;
+    private String documentId; // nullable for some types
+    private String commentsDate; // nullable
+    private String comments;     // nullable
+    private String pioName;      // nullable
+}
+

--- a/rti-master/src/main/java/nic/rti/master/service/FAAPendingRequestService.java
+++ b/rti-master/src/main/java/nic/rti/master/service/FAAPendingRequestService.java
@@ -1,0 +1,8 @@
+package nic.rti.master.service;
+
+import nic.rti.master.dto.FinalResponseDTO;
+import nic.rti.master.dto.PendingRequestDTO;
+
+public interface FAAPendingRequestService {
+    FinalResponseDTO fetchPendingRequests(PendingRequestDTO requestDTO);
+}

--- a/rti-master/src/main/java/nic/rti/master/service/impl/FAAPendingRequestServiceImpl.java
+++ b/rti-master/src/main/java/nic/rti/master/service/impl/FAAPendingRequestServiceImpl.java
@@ -1,0 +1,62 @@
+package nic.rti.master.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import nic.rti.master.dto.*;
+import nic.rti.master.dao.FAAPendingRequestRepository;
+import nic.rti.master.service.FAAPendingRequestService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FAAPendingRequestServiceImpl implements FAAPendingRequestService {
+
+    private final FAAPendingRequestRepository faaRepo;
+
+    @Override
+    public FinalResponseDTO fetchPendingRequests(PendingRequestDTO requestDTO) {
+        String recordsType = requestDTO.getRecordsType();
+        Integer applId = requestDTO.getApplId();
+        Integer limit = requestDTO.getLimit();
+        Integer offset = requestDTO.getOffset();
+
+        List<PendingRequestResponseDTO> result;
+        long totalCount;
+
+        switch (recordsType) {
+            case "UNDER_PROCESS":
+                result = faaRepo.fetchUnderProcess(applId, limit, offset);
+                totalCount = faaRepo.countUnderProcess(applId);
+                break;
+
+//            case "COMMENT_CPIO":
+//                result = faaRepo.fetchCommentCPIO(applId, limit, offset);
+//                totalCount = faaRepo.countCommentCPIO(applId);
+//                break;
+//
+//            case "MODIFY":
+//                result = faaRepo.fetchModify(applId, limit, offset);
+//                totalCount = faaRepo.countModify(applId);
+//                break;
+//
+//            case "NEW":
+//                result = faaRepo.fetchNew(applId, limit, offset);
+//                totalCount = faaRepo.countNew(applId);
+//                break;
+//
+//            case "PENDING_20_DAYS":
+//                result = faaRepo.fetchPending20Days(applId, limit, offset);
+//                totalCount = faaRepo.countPending20Days(applId);
+//                break;
+
+            default:
+                throw new IllegalArgumentException("Invalid record type: " + recordsType);
+        }
+
+        boolean hasMore = totalCount > (offset + result.size());
+        PaginationDTO pagination = new PaginationDTO(limit, offset, totalCount, hasMore);
+
+        return new FinalResponseDTO("success", result, pagination);
+    }
+}


### PR DESCRIPTION
Endpoints : GET /rti-faa/pending-requests?records_type=UNDER_PROCESS&appl_id={applId}&limit={limit}&offset={offset}


1. Fully implemented the API to fetch pending requests for record type UNDER_PROCESS.
2. The fetchUnderProcess() method connects to the database using a native SQL query and returns properly mapped results in a DTO format.
3. Temporarily added a dummy method countUnderProcess() just for testing the pagination logic. We will improve or replace this later when real logic is finalized.



 Tested and Verified : 
This feature was tested on the browser using:
http://localhost:8080/rti-master/rti-faa/pending-requests?records_type=UNDER_PROCESS&appl_id=123&limit=10&offset=0

 Verified successful response in browser
 Returns expected data structure and fields
Confirmed the native SQL query works correctly with the database tables (appeal and action_history).

📂 Files Created in This Feature:
1. PendingRequestDTO.java
2. PendingRequestResponseDTO.java
3. PaginationDTO.java
4. FinalResponseDTO.java
5. FAAPendingRequestRepository.java
6. FAAPendingRequestRepositoryImpl.java
7. FAAPendingRequestService.java
8. FAAPendingRequestServiceImpl.java
9. FAAPendingRequestController.java