### PR TITLE
Development _ Add complete GetPendingRequest module with controller, service, and repository in rti-master @antika_das

### DIFF
--- a/rti-master/src/main/java/nic/rti/master/controller/GetPendingRequestController.java
+++ b/rti-master/src/main/java/nic/rti/master/controller/GetPendingRequestController.java
@@ -1,0 +1,58 @@
+// antika
+
+package nic.rti.master.controller;
+
+import nic.rti.master.service.GetPendingRequestService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/rti-faa")
+public class GetPendingRequestController {
+
+    @Autowired
+    private GetPendingRequestService service;
+
+    @GetMapping("/pending-requests")
+    public ResponseEntity<?> getPendingRequests(
+            @RequestParam String records_type,
+            @RequestParam String appl_id,
+            @RequestParam(defaultValue = "50") Integer limit,
+            @RequestParam(defaultValue = "0") Integer offset
+    ) {
+        try {
+            List<Map<String, Object>> data = service.getPendingRequests(records_type, appl_id, limit, offset);
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "success");
+            response.put("data", data);
+            response.put("pagination", Map.of(
+                    "limit", limit,
+                    "offset", offset,
+                    "total_count", data.size(),
+                    "has_more", data.size() == limit
+            ));
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "status", "error",
+                    "error_code", "INVALID_RECORD_TYPE",
+                    "message", e.getMessage(),
+                    "timestamp", new Date().toString()
+            ));
+        } catch (Exception e) {
+            e.printStackTrace(); 
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("status", "error");
+            errorResponse.put("error_code", "DATABASE_ERROR");
+            errorResponse.put("message", e.getMessage());
+            errorResponse.put("timestamp", new Date().toString());
+
+            return ResponseEntity.internalServerError().body(errorResponse);
+        }
+    }
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/PendingRequestRepository.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/PendingRequestRepository.java
@@ -1,0 +1,14 @@
+// antika 
+
+package nic.rti.master.dao;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PendingRequestRepository {
+    List<Map<String, Object>> getUnderProcess(String applId, int limit, int offset);
+    List<Map<String, Object>> getCommentCpio(String applId, int limit, int offset);
+    List<Map<String, Object>> getModify(String applId, int limit, int offset);
+    List<Map<String, Object>> getNew(String applId, int limit, int offset);
+    List<Map<String, Object>> getPending20Days(String applId, int limit, int offset);
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/PendingRequestRepositoryImpl.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/PendingRequestRepositoryImpl.java
@@ -1,0 +1,134 @@
+package nic.rti.master.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Tuple;
+import jakarta.persistence.TupleElement;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+public class PendingRequestRepositoryImpl implements PendingRequestRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Map<String, Object> tupleToMap(Tuple tuple) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        for (TupleElement<?> elem : tuple.getElements()) {
+            map.put(elem.getAlias(), tuple.get(elem));
+        }
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+private List<Map<String, Object>> executeTupleQuery(String sql, Map<String, Object> params) {
+    Query query = entityManager.createNativeQuery(sql, Tuple.class);
+    params.forEach(query::setParameter);
+
+    List<Tuple> tuples = (List<Tuple>) query.getResultList();
+
+    return tuples.stream().map(this::tupleToMap).collect(Collectors.toList());
+}
+
+
+    @Override
+    public List<Map<String, Object>> getUnderProcess(String applId, int limit, int offset) {
+        String sql = """
+            SELECT A.registration_no, A.name,
+                   TO_CHAR(A.recvd_date, 'DD/MM/YYYY') as recvd_date,
+                   A.entry_date
+            FROM \"RTIMIS\".appeal A
+            JOIN \"RTIMIS\".action_history AH ON A.registration_no = AH.registration_no
+            WHERE AH.action_srno = (
+                SELECT MAX(action_srno)
+                FROM \"RTIMIS\".action_history
+                WHERE registration_no = A.registration_no
+            )
+            AND AH.action_status IN ('70', '7A', '7D', '7C')
+            AND A.closing_date IS NULL
+            AND A.\"ApplID\" = :applId
+            ORDER BY A.entry_date DESC
+            LIMIT :limit OFFSET :offset
+        """;
+        return executeTupleQuery(sql, Map.of("applId", applId, "limit", limit, "offset", offset));
+    }
+
+    @Override
+    public List<Map<String, Object>> getCommentCpio(String applId, int limit, int offset) {
+        String sql = """
+            SELECT C.registration_no, A.name,
+                   TO_CHAR(A.recvd_date, 'DD/MM/YYYY') as recvd_date,
+                   A.entry_date,
+                   P.\"Name\" as Name,
+                   TO_CHAR(C.comments_date, 'DD/MM/YYYY') as comments_date,
+                   C.comments
+            FROM \"RTIMIS\".\"commentsCPIO\" C
+            JOIN \"RTIMIS\".appeal A ON C.registration_no = A.registration_no
+            JOIN \"RTIMIS\".\"PIODetails\" P ON A.cpio_app = P.pio_id
+            WHERE C.flag = 'R'
+              AND P.\"ActiveIdle\" = 'Y'
+              AND A.closing_date IS NULL
+              AND A.\"ApplID\" = :applId
+            ORDER BY A.entry_date DESC
+            LIMIT :limit OFFSET :offset
+        """;
+        return executeTupleQuery(sql, Map.of("applId", applId, "limit", limit, "offset", offset));
+    }
+
+    @Override
+    public List<Map<String, Object>> getModify(String applId, int limit, int offset) {
+        String sql = """
+            SELECT registration_no, name,
+                   TO_CHAR(recvd_date, 'DD/MM/YYYY') as recvd_date,
+                   document_id, entry_date
+            FROM \"RTIMIS\".appeal
+            WHERE closing_date IS NULL
+              AND \"ApplID\" = :applId
+              AND registration_no NOT IN (
+                  SELECT registration_no
+                  FROM \"RTIMIS\".app_assessment_details
+              )
+            ORDER BY entry_date DESC
+            LIMIT :limit OFFSET :offset
+        """;
+        return executeTupleQuery(sql, Map.of("applId", applId, "limit", limit, "offset", offset));
+    }
+
+    @Override
+    public List<Map<String, Object>> getNew(String applId, int limit, int offset) {
+        return getModify(applId, limit, offset);
+    }
+
+    @Override
+    public List<Map<String, Object>> getPending20Days(String applId, int limit, int offset) {
+        String sql = """
+            WITH ApplCodeCTE AS (
+                SELECT \"ApplCode\" FROM \"RTIMIS\".\"Appellate\"
+                WHERE \"ApplId\" = :applId AND \"ActiveIdle\" = 'Y'
+                LIMIT 1
+            )
+            SELECT DISTINCT A.registration_no, A.name,
+                   TO_CHAR(A.recvd_date, 'DD/MM/YYYY') as recvd_date,
+                   A.entry_date
+            FROM \"RTIMIS\".appeal A
+            WHERE A.closing_date IS NULL
+              AND A.\"ApplID\" = :applId
+              AND (CURRENT_DATE - DATE(A.recvd_date)) > 20
+              AND A.registration_no NOT IN (
+                  SELECT registration_no
+                  FROM \"RTIMIS\".action_history AH
+                  WHERE AH.action_status = '7C'
+                    AND CAST(AH.do_code AS INTEGER) = (SELECT \"ApplCode\" FROM ApplCodeCTE)
+              )
+            ORDER BY A.entry_date DESC
+            LIMIT :limit OFFSET :offset
+        """;
+        return executeTupleQuery(sql, Map.of("applId", applId, "limit", limit, "offset", offset));
+    }
+} 

--- a/rti-master/src/main/java/nic/rti/master/service/GetPendingRequestService.java
+++ b/rti-master/src/main/java/nic/rti/master/service/GetPendingRequestService.java
@@ -1,0 +1,37 @@
+// antika
+
+
+package nic.rti.master.service;
+
+import nic.rti.master.dao.PendingRequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class GetPendingRequestService {
+
+    @Autowired
+    private PendingRequestRepository pendingRequestRepository;
+
+    public List<Map<String, Object>> getPendingRequests(String recordsType, String applId, int limit, int offset) {
+    switch (recordsType.toUpperCase()) {
+        case "UNDER_PROCESS":
+            return pendingRequestRepository.getUnderProcess(applId, limit, offset);
+        case "COMMENT_CPIO":
+            return pendingRequestRepository.getCommentCpio(applId, limit, offset);
+        case "MODIFY":
+            return pendingRequestRepository.getModify(applId, limit, offset);
+        case "NEW":
+            return pendingRequestRepository.getNew(applId, limit, offset);
+        case "PENDING_20_DAYS":
+            return pendingRequestRepository.getPending20Days(applId, limit, offset);
+        default:
+            throw new IllegalArgumentException("Invalid records_type. Allowed: UNDER_PROCESS, COMMENT_CPIO, MODIFY, NEW, PENDING_20_DAYS");
+    }
+}
+
+
+}
+


### PR DESCRIPTION
As per the assigned task, both I and another team member were working on the /rti-faa/pending-requests route. He committed changes to the existing FAAPendingRequestController.java file (as per the provided format), but his implementation is still incomplete.

Since I completed the full logic for all request types (UNDER_PROCESS, COMMENT_CPIO, MODIFY, NEW, and PENDING_20_DAYS), I decided not to overwrite or delete his file as he is still working on it.

Instead, I have created a separate working version named GetPendingRequestController.java to avoid conflicts. This allows the admin to review and compare both implementations and keep the more complete and efficient one.

The following files have been added:
- `controller/GetPendingRequestController.java`
- `service/GetPendingRequestService.java`
- `dao/PendingRequestRepository.java`
- `dao/PendingRequestRepositoryImpl.java`

The code is tested and fully functional for all the required request types.

ex - > 
  http://localhost:8080/rti-master/rti-faa/pending-requests?records_type=MODIFY&appl_id=123&limit=50&offset=0
 output -> {
  "pagination": {
    "has_more": false,
    "limit": 50,
    "offset": 0,
    "total_count": 0
  },
  "data": [],
  "status": "success"
}
