### PR TITLE
Hemant — Add backend APIs for Nodal Officer Dashboard

### DIFF
--- a/rti-master/src/main/java/nic/rti/master/controller/NodalDashboardController.java
+++ b/rti-master/src/main/java/nic/rti/master/controller/NodalDashboardController.java
@@ -1,0 +1,27 @@
+package nic.rti.master.controller;
+
+import nic.rti.master.service.GetDashboardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/nodal")
+@CrossOrigin
+public class NodalDashboardController {
+
+    @Autowired
+    private GetDashboardService dashboardService;
+
+    @GetMapping("/dashboard/counts")
+    public ResponseEntity<Map<String, Long>> getDashboardCounts() {
+        Map<String, Long> result = new HashMap<>();
+        result.put("newRequests", dashboardService.getNewRequestCount());
+        result.put("newAppeals", dashboardService.getNewAppealCount());
+        result.put("calledDocuments", dashboardService.getDocumentCalledCount());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/AppealRepository.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/AppealRepository.java
@@ -1,0 +1,8 @@
+package nic.rti.master.dao;
+
+import nic.rti.master.entity.AppealEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppealRepository extends JpaRepository<AppealEntity, Long> {
+    Long countByStatus(String status);
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/RequestDocumentRepository.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/RequestDocumentRepository.java
@@ -1,0 +1,8 @@
+package nic.rti.master.dao;
+
+import nic.rti.master.entity.RequestDocumentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestDocumentRepository extends JpaRepository<RequestDocumentEntity, Long> {
+    Long countByCalledTrue();
+}

--- a/rti-master/src/main/java/nic/rti/master/dao/RequestRepository.java
+++ b/rti-master/src/main/java/nic/rti/master/dao/RequestRepository.java
@@ -1,0 +1,8 @@
+package nic.rti.master.dao;
+
+import nic.rti.master.entity.RequestEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestRepository extends JpaRepository<RequestEntity, Long> {
+    Long countByStatus(String status);
+}

--- a/rti-master/src/main/java/nic/rti/master/entity/AppealEntity.java
+++ b/rti-master/src/main/java/nic/rti/master/entity/AppealEntity.java
@@ -1,0 +1,30 @@
+package nic.rti.master.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "tbl_appeal")
+public class AppealEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String status;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/rti-master/src/main/java/nic/rti/master/entity/RequestDocumentEntity.java
+++ b/rti-master/src/main/java/nic/rti/master/entity/RequestDocumentEntity.java
@@ -1,0 +1,40 @@
+package nic.rti.master.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "tbl_documents")
+public class RequestDocumentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long requestId;
+
+    private boolean called;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(Long requestId) {
+        this.requestId = requestId;
+    }
+
+    public boolean isCalled() {
+        return called;
+    }
+
+    public void setCalled(boolean called) {
+        this.called = called;
+    }
+}

--- a/rti-master/src/main/java/nic/rti/master/entity/RequestEntity.java
+++ b/rti-master/src/main/java/nic/rti/master/entity/RequestEntity.java
@@ -1,0 +1,31 @@
+package nic.rti.master.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "tbl_request")  // your database table name
+public class RequestEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String status;
+
+    // Add getters and setters (or use Lombok if already in project)
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/rti-master/src/main/java/nic/rti/master/service/GetDashboardService.java
+++ b/rti-master/src/main/java/nic/rti/master/service/GetDashboardService.java
@@ -1,0 +1,7 @@
+package nic.rti.master.service;
+
+public interface GetDashboardService {
+    Long getNewRequestCount();
+    Long getNewAppealCount();
+    Long getDocumentCalledCount();
+}

--- a/rti-master/src/main/java/nic/rti/master/service/impl/GetDashboardServiceImpl.java
+++ b/rti-master/src/main/java/nic/rti/master/service/impl/GetDashboardServiceImpl.java
@@ -1,0 +1,36 @@
+package nic.rti.master.service.impl;
+
+import nic.rti.master.dao.RequestRepository;
+import nic.rti.master.dao.AppealRepository;
+import nic.rti.master.dao.RequestDocumentRepository;
+import nic.rti.master.service.GetDashboardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GetDashboardServiceImpl implements GetDashboardService {
+
+    @Autowired
+    private RequestRepository requestRepository;
+
+    @Autowired
+    private AppealRepository appealRepository;
+
+    @Autowired
+    private RequestDocumentRepository documentRepository;
+
+    @Override
+    public Long getNewRequestCount() {
+        return requestRepository.countByStatus("NEW");
+    }
+
+    @Override
+    public Long getNewAppealCount() {
+        return appealRepository.countByStatus("NEW");
+    }
+
+    @Override
+    public Long getDocumentCalledCount() {
+        return documentRepository.countByCalledTrue();
+    }
+}


### PR DESCRIPTION
Implemented backend API for Nodal Officer Dashboard.Returns counts for new requests, new appeals, and called documents.